### PR TITLE
fix(ci): inline test steps to comply with org actions allow-list

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,12 +8,6 @@ on:
   - cron: '25 08 * * *'
 
   workflow_dispatch:
-    inputs:
-      debug_enabled:
-        type: boolean
-        description: Debug with tmate
-        required: false
-        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -34,10 +28,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Install Homebrew
+      - name: Set up Homebrew
         run: |
-          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
           echo "/home/linuxbrew/.linuxbrew/bin" >> "$GITHUB_PATH"
+          echo "/home/linuxbrew/.linuxbrew/sbin" >> "$GITHUB_PATH"
 
       - name: Install test dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,10 +32,33 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: ddev/github-action-add-on-test@f040e6e6a6cada43dc75985f60c6a856c350f16e
-        with:
-          ddev_version: ${{ matrix.ddev_version }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          debug_enabled: ${{ github.event.inputs.debug_enabled }}
-          addon_repository: ${{ env.GITHUB_REPOSITORY }}
-          addon_ref: ${{ env.GITHUB_REF }}
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Homebrew
+        run: |
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          echo "/home/linuxbrew/.linuxbrew/bin" >> "$GITHUB_PATH"
+
+      - name: Install test dependencies
+        run: |
+          brew tap bats-core/bats-core
+          brew install bats-core bats-file bats-assert bats-support jq mkcert yq
+          mkcert -install
+
+      - name: Install DDEV (stable)
+        if: matrix.ddev_version == 'stable'
+        run: brew install ddev/ddev/ddev
+
+      - name: Install DDEV (HEAD)
+        if: matrix.ddev_version == 'HEAD'
+        run: brew install --HEAD ddev/ddev/ddev
+
+      - name: Download DDEV docker images
+        run: ddev debug download-images
+
+      - name: Run tests
+        env:
+          DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DDEV_NONINTERACTIVE: "true"
+          DDEV_NO_INSTRUMENTATION: "true"
+        run: bats tests --filter-tags '!release'


### PR DESCRIPTION
## Summary

CI has been failing since ~March 6 because the `ddev/github-action-add-on-test` composite action
internally uses actions not permitted by the TYPO3-Documentation org's GitHub Actions allow-list:

- `homebrew/actions/setup-homebrew@main` — not in allow-list, not SHA-pinned
- `mxschmitt/action-tmate@v3` — not in allow-list, not SHA-pinned
- `actions/checkout@v4` — allowed pattern exists, but org requires full SHA pinning

This PR replaces the composite action with equivalent inline steps that only use:
- `actions/checkout` pinned to full commit SHA
- Shell commands for Homebrew, bats, mkcert, and DDEV installation

The test logic (`bats tests --filter-tags '!release'`) and matrix strategy (`stable` / `HEAD`) remain identical.

The `debug_enabled` / tmate input is dropped since `mxschmitt/action-tmate` is not in the allow-list.
If remote debugging is needed, it could be re-added by installing tmate via apt/brew directly.

## Test plan

- [ ] CI passes on this PR for both matrix variants (`stable` and `HEAD`)
- [ ] Scheduled daily runs resume succeeding on `main` after merge